### PR TITLE
fix an overly strict constraint in the huffman table generation logic, w...

### DIFF
--- a/coding/huffmantemplate.cpp
+++ b/coding/huffmantemplate.cpp
@@ -548,7 +548,7 @@ void HuffmanTemplate::BuildDecoder(void)
 	  JPG_THROW(MALFORMED_STREAM,"HuffmanTemplate::ParseMarker","Huffman table marker depends on undefined data");
 	// There are codes of this lengths.
 	code += m_ucLengths[i];
-	if (code >= 1UL << (i + 1))
+	if (code > 1UL << (i + 1) || (code == 1UL << (i + 1) && values + m_ucLengths[i] < m_pucValues + m_ulCodewords))
 	  JPG_THROW(MALFORMED_STREAM,"HuffmanTemplate::ParseMarker",
 		    "Huffman table corrupt - entry depends on more bits than available for the bit length");
 	class HuffmanDecoder *huff = new(m_pEnviron) class HuffmanDecoder(values,i+1-lastbits,


### PR DESCRIPTION
...hich causes the software to throw an error and reject legal huffman tables.

I am using your library to decode CinemaDNG images from a new BlackMagic Ursula cinema camera.  It failed to decode the images with the following error:

> reading a JPEG file failed - error -1038 - Huffman table corrupt - entry depends on more bits than available for the bit length

To debug this, I place the following statement at line 546:

>      printf("Huffman table: There are %i code words with length %i\n", m_ucLengths[i], i+1);

The output was:

> Huffman table: There are 0 code words with length 1
> Huffman table: There are 3 code words with length 2
> Huffman table: There are 1 code words with length 3
> Huffman table: There are 1 code words with length 4
> Huffman table: There are 1 code words with length 5
> Huffman table: There are 1 code words with length 6
> Huffman table: There are 1 code words with length 7
> Huffman table: There are 1 code words with length 8
> Huffman table: There are 1 code words with length 9
> Huffman table: There are 1 code words with length 10
> Huffman table: There are 1 code words with length 11
> Huffman table: There are 1 code words with length 12
> Huffman table: There are 2 code words with length 13

So it's a legal table, but the last 3 bit lengths have no code values.  As a result of the truncated (but legal) table, this huffman generator logic throws an error.  My code change applies the correct constraint which allows for tables which end early, but will still fail tables which are actually corrupted.