### PR TITLE
Fix minor typos

### DIFF
--- a/boxes/box.cpp
+++ b/boxes/box.cpp
@@ -153,7 +153,7 @@ class Box *Box::ParseBoxMarker(class Tables *tables,class Box *&boxlist,class By
       // This box will fit. Check whether the box size is consistent.
       if (box->m_uqBoxSize != lbox)
         JPG_THROW(MALFORMED_STREAM,"Box::ParseBoxMarker","JPEG stream is malformed, "
-                  "box size is not consistent accross APP11 markers");
+                  "box size is not consistent across APP11 markers");
       assert(box->m_pInputStream);
       break;
     }

--- a/cmd/main.cpp
+++ b/cmd/main.cpp
@@ -233,7 +233,7 @@ void PrintUsage(const char *progname)
           "-ncl       : disable clamping of out-of-gamut colors.\n"
           "             this is automatically enabled for lossless.\n"
 #if ACCUSOFT_CODE
-          "-m maxerr  : defines a maximum pixel errror for JPEG LS coding\n"
+          "-m maxerr  : defines a maximum pixel error for JPEG LS coding\n"
 #endif
           "-h         : optimize the Huffman tables\n"
 #if ACCUSOFT_CODE
@@ -259,7 +259,7 @@ void PrintUsage(const char *progname)
           "             mapping HDR to LDR. A suggested value is 2.4 for mapping scRGB to sRBG.\n"
           "             This option controls the base-nonlinearity that generates the\n"
           "             HDR pre-cursor image from the LDR image. It is also used in the\n"
-          "             absense of -ldr (i.e. no LDR image) to tonemap the HDR input image.\n"
+          "             absence of -ldr (i.e. no LDR image) to tonemap the HDR input image.\n"
           "             Use -g 0 to use an approximate inverse TMO as base-nonlinearity, and\n"
           "             for tonemapping with the Reinhard operator if the LDR image is missing.\n"
           "-gf file   : define the inverse one-point L-nonlinearity on decoding from a file\n"

--- a/codestream/image.cpp
+++ b/codestream/image.cpp
@@ -271,7 +271,7 @@ void Image::InstallDefaultParameters(ULONG width,ULONG height,UBYTE depth,
           // This makes really little sense if the image becomes degenerated.
           if (w < 2 || h < 2) {
             JPG_THROW(OVERFLOW_PARAMETER,"Image::InstallDefaultParameters",
-                      "image dimensions become too small for resonable hierarchical coding "
+                      "image dimensions become too small for reasonable hierarchical coding "
                       "reduce the number of levels");
           }
           w = (w + 1) >> 1; // always scaled in both dimensions in this program.

--- a/control/bitmapctrl.cpp
+++ b/control/bitmapctrl.cpp
@@ -153,7 +153,7 @@ void BitmapCtrl::RequestUserData(class BitMapHook *bmh,const RectAngle<LONG> &r,
     m_ucPixelType = m_ppBitmap[comp]->ibm_ucPixelType;
   } else if (m_ppBitmap[comp]->ibm_ucPixelType) {
     if (m_ucPixelType != m_ppBitmap[comp]->ibm_ucPixelType) {
-      JPG_THROW(INVALID_PARAMETER,"BitmapCtrl::RequestUserData","pixel types must be consistent accross components");
+      JPG_THROW(INVALID_PARAMETER,"BitmapCtrl::RequestUserData","pixel types must be consistent across components");
     }
   }
 

--- a/marker/adobemarker.cpp
+++ b/marker/adobemarker.cpp
@@ -99,7 +99,7 @@ void AdobeMarker::ParseMarker(class ByteStream *io,UWORD len)
   LONG color;
 
   if (len != 2 + 5 + 2 + 2 + 2 + 1)
-    JPG_THROW(MALFORMED_STREAM,"AdobeMarker::ParseMarker","misformed Adobe marker");
+    JPG_THROW(MALFORMED_STREAM,"AdobeMarker::ParseMarker","malformed Adobe marker");
 
   version = io->GetWord();
   if (version != 100) // Includes EOF

--- a/marker/exifmarker.cpp
+++ b/marker/exifmarker.cpp
@@ -117,7 +117,7 @@ void EXIFMarker::WriteMarker(class ByteStream *io)
 void EXIFMarker::ParseMarker(class ByteStream *io,UWORD len)
 {
   if (len < 2 + 4 + 2 + 2 + 2 + 4 + 2 + 4)
-    JPG_THROW(MALFORMED_STREAM,"EXIFMarker::ParseMarker","misformed EXIF marker");
+    JPG_THROW(MALFORMED_STREAM,"EXIFMarker::ParseMarker","malformed EXIF marker");
 
   //
   // The exif header has already been parsed off.

--- a/marker/jfifmarker.cpp
+++ b/marker/jfifmarker.cpp
@@ -105,7 +105,7 @@ void JFIFMarker::ParseMarker(class ByteStream *io,UWORD len)
   UBYTE unit;
   
   if (len < 2 + 5 + 2 + 1 + 2 + 2 + 1 + 1)
-    JPG_THROW(MALFORMED_STREAM,"JFIFMarker::ParseMarker","misformed JFIF marker");
+    JPG_THROW(MALFORMED_STREAM,"JFIFMarker::ParseMarker","malformed JFIF marker");
 
   io->Get(); // version
   io->Get(); // revision


### PR DESCRIPTION
- absense absence
- accross across
- errror error
- misformed malformed
- resonable reasonable