### PR TITLE
Use Python 3 print function instead

### DIFF
--- a/doxyfilter.py
+++ b/doxyfilter.py
@@ -1,43 +1,42 @@
 #!/usr/bin/python
 
+from __future__ import print_function
 import fileinput
 import string
 import re
 
 commentblock = 0
 emptycomment = re.compile("^//$")
-fullcomment  = re.compile("^//.")
-foldmarker   = re.compile("^///")
-hppfile      = re.compile("^.*\.hpp$")
+fullcomment = re.compile("^//.")
+foldmarker = re.compile("^///")
+hppfile = re.compile("^.*\.hpp$")
 for line in fileinput.input():
-	if hppfile.match(fileinput.filename()):
-		line  = string.expandtabs(line)
-		token = string.strip(line)
-		indent = len(line) - len(string.lstrip(line))
-		if (indent > 0):
-			blanks = string.ljust("",indent-1)
-		else:
-			blanks = ""
-		if emptycomment.match(token):
-			continue
-		if fullcomment.match(token) and not foldmarker.match(token):
-			if commentblock:
-				print re.sub("//","  ",line),
-			else:
-				print
-				print blanks,
-				print "/*!"
-				print re.sub("//","  ",line),
-				commentblock = 1
-		else:
-			if commentblock:
-				print blanks,
-				print " */"
-				print line,
-				commentblock = 0
-			else:
-				print line,
-	else:
-		print line,
-
-
+    if hppfile.match(fileinput.filename()):
+        line = string.expandtabs(line)
+        token = string.strip(line)
+        indent = len(line) - len(string.lstrip(line))
+        if (indent > 0):
+            blanks = string.ljust("", indent-1)
+        else:
+            blanks = ""
+        if emptycomment.match(token):
+            continue
+        if fullcomment.match(token) and not foldmarker.match(token):
+            if commentblock:
+                print(re.sub("//", "  ", line))
+            else:
+                print()
+                print(blanks)
+                print("/*!")
+                print(re.sub("//", "  ", line))
+                commentblock = 1
+        else:
+            if commentblock:
+                print(blanks)
+                print(" */")
+                print(line)
+                commentblock = 0
+            else:
+                print(line)
+    else:
+        print(line)


### PR DESCRIPTION
I saw some syntax error about `doxyfilter.py`'s python2 `print ` when I cross-compile this library. Therefore I made this PR to use Python 3 print functionn. `from __future__ import print_function` will allow python 2 to run this script successfully. 