### PR TITLE
Use marker assigned naming convention from ITU 87

### DIFF
--- a/codestream/jpeglsscan.cpp
+++ b/codestream/jpeglsscan.cpp
@@ -206,7 +206,7 @@ void JPEGLSScan::FindComponentDimensions(void)
 // Write the marker that indicates the frame type fitting to this scan.
 void JPEGLSScan::WriteFrameType(class ByteStream *io)
 {
-  io->PutWord(0xfff7); // JPEG LS
+  io->PutWord(0xfff7); // JPEG LS SOF55
 }
 ///
 

--- a/codestream/tables.cpp
+++ b/codestream/tables.cpp
@@ -1349,7 +1349,7 @@ bool Tables::ParseTablesIncremental(class ByteStream *io,class Checksum *chk,
    case 0xffd9: // EOI
    case 0xffda: // Start of scan.
    case 0xffde: // DHP
-   case 0xfff7: // JPEG LS SOS
+   case 0xfff7: // JPEG LS SOF55
      return false;
    case 0xffff: // A filler byte followed by a marker. Skip.
      io->Get();

--- a/interface/jpeg.cpp
+++ b/interface/jpeg.cpp
@@ -567,7 +567,7 @@ JPG_LONG JPEG::InternalPeekMarker(struct JPG_TagItem *) const
   case 0xffd9: // EOI
   case 0xffda: // Start of scan.
   case 0xffde: // DHP
-  case 0xfff7: // JPEG LS SOS
+  case 0xfff7: // JPEG LS SOF55
     // These are all markers that cannot be handled externally in any case.
     return 0;
   }

--- a/marker/frame.cpp
+++ b/marker/frame.cpp
@@ -1032,7 +1032,7 @@ bool Frame::ParseTrailer(class ByteStream *io)
     case 0xffc9:
     case 0xffca:
     case 0xffcb:
-    case 0xfff7: // JPEG LS SOS
+    case 0xfff7: // JPEG LS SOF55
       // All non-differential frames, may not appear in a hierarchical process.
       JPG_WARN(MALFORMED_STREAM,"Frame::ParseTrailer",
                "found a non-differential frame start behind the initial frame");


### PR DESCRIPTION
SOF55 (X'FFF7') identifies a new Start of Frame marker for JPEG-LS processes.