### PR TITLE
Use defaults when LSE parameters are set to zero.

### DIFF
--- a/codestream/jpeglsscan.cpp
+++ b/codestream/jpeglsscan.cpp
@@ -142,9 +142,9 @@ void JPEGLSScan::FindComponentDimensions(void)
   if (thres == NULL) {
     if (m_pDefaultThresholds == NULL)
       m_pDefaultThresholds = new(m_pEnviron) class Thresholds(m_pEnviron);
-    m_pDefaultThresholds->InstallDefaults(m_pFrame->PrecisionOf(),m_lNear);
     thres = m_pDefaultThresholds;
   }
+  thres->InstallDefaults(m_pFrame->PrecisionOf(),m_lNear);
 
   m_lMaxVal = thres->MaxValOf();
   m_lT1     = thres->T1Of();

--- a/marker/thresholds.cpp
+++ b/marker/thresholds.cpp
@@ -98,31 +98,45 @@ void Thresholds::ParseMarker(class ByteStream *io,UWORD len)
 // Install the defaults for a given bits per pixel value.
 void Thresholds::InstallDefaults(UBYTE bpp,UWORD near)
 {
-  m_usMaxVal = (1 << bpp) - 1;
-  
+  if (m_usMaxVal == 0)
+    m_usMaxVal = (1 << bpp) - 1;
+
   if (m_usMaxVal >= 128) {
     UWORD factor = m_usMaxVal;
     if (factor > 4095)
       factor = 4095;
     factor = (factor + 128) >> 8;
-    m_usT1 = factor * ( 3 - 2) + 2 + 3 * near;
-    if (m_usT1 > m_usMaxVal || m_usT1 < near + 1) m_usT1 = near + 1;
-    m_usT2 = factor * ( 7 - 3) + 3 + 5 * near;
-    if (m_usT2 > m_usMaxVal || m_usT2 < m_usT1  ) m_usT2 = m_usT1;
-    m_usT3 = factor * (21 - 4) + 4 + 7 * near;
-    if (m_usT3 > m_usMaxVal || m_usT3 < m_usT2  ) m_usT3 = m_usT2;
+    if (m_usT1 == 0) {
+      m_usT1 = factor * ( 3 - 2) + 2 + 3 * near;
+      if (m_usT1 > m_usMaxVal || m_usT1 < near + 1) m_usT1 = near + 1;
+    }
+    if (m_usT2 == 0) {
+      m_usT2 = factor * ( 7 - 3) + 3 + 5 * near;
+      if (m_usT2 > m_usMaxVal || m_usT2 < m_usT1  ) m_usT2 = m_usT1;
+    }
+    if (m_usT3 == 0) {
+      m_usT3 = factor * (21 - 4) + 4 + 7 * near;
+      if (m_usT3 > m_usMaxVal || m_usT3 < m_usT2  ) m_usT3 = m_usT2;
+    }
   } else {
     UWORD factor = 256 / (m_usMaxVal + 1);
-    m_usT1 = 3 / factor + 3 * near;
-    if (m_usT1 < 2) m_usT1 = 2;
-    if (m_usT1 > m_usMaxVal || m_usT1 < near + 1) m_usT1 = near + 1;
-    m_usT2 = 7 / factor + 5 * near;
-    if (m_usT2 < 3) m_usT2 = 3;
-    if (m_usT2 > m_usMaxVal || m_usT2 < m_usT1  ) m_usT2 = m_usT1;
-    m_usT3 = 21 / factor + 7 * near;
-    if (m_usT3 < 4) m_usT3 = 4;
-    if (m_usT3 > m_usMaxVal || m_usT3 < m_usT2  ) m_usT3 = m_usT2;
+    if (m_usT1 == 0) {
+      m_usT1 = 3 / factor + 3 * near;
+      if (m_usT1 < 2) m_usT1 = 2;
+      if (m_usT1 > m_usMaxVal || m_usT1 < near + 1) m_usT1 = near + 1;
+    }
+    if (m_usT2 == 0) {
+      m_usT2 = 7 / factor + 5 * near;
+      if (m_usT2 < 3) m_usT2 = 3;
+      if (m_usT2 > m_usMaxVal || m_usT2 < m_usT1  ) m_usT2 = m_usT1;
+    }
+    if (m_usT3 == 0) {
+      m_usT3 = 21 / factor + 7 * near;
+      if (m_usT3 < 4) m_usT3 = 4;
+      if (m_usT3 > m_usMaxVal || m_usT3 < m_usT2  ) m_usT3 = m_usT2;
+    }
   }
-  m_usReset  = 64;
+  if (m_usReset == 0)
+    m_usReset  = 64;
 }
 ///


### PR DESCRIPTION
From ITU T.87 C.2.4.1.1:
"For MAXVAL, T1, T2, T3 and RESET, a value of 0 indicates reverting to default values as given in Table C.2. The SOI marker also resets these parameters to default values given in Table C.2."

The existing code was doing this for SOI but not handling these being zero when the LSE segment is decoded.